### PR TITLE
read config from 'build'

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,14 @@ module.exports = {
         }
       },
 
+      beforeHook: function(context) {
+        if (!context.config[this.name]) {
+          context.config[this.name] = context.config['build'];
+        }
+        
+        this._super.beforeHook.apply(this, arguments);
+      },
+
       setup: function() {
         var outputPath = this.readConfig('outputPath');
         return {


### PR DESCRIPTION
This fixes the problem that deploy.js uses ENV.build, but that is not read by this plugin, as the name here is 'build-plus'.